### PR TITLE
Conform MacAddress to Sendable

### DIFF
--- a/Sources/MacAddress/MacAddress.swift
+++ b/Sources/MacAddress/MacAddress.swift
@@ -2,7 +2,7 @@ import Foundation
 import IOKit
 
 /// A structure representing a MAC address.
-public struct MacAddress: Equatable, Hashable {
+public struct MacAddress: Equatable, Hashable, Sendable {
     /// The raw bytes of the MAC address.
     public let rawData: Data
 


### PR DESCRIPTION
Required to avoid compiler errors:
warning: static property 'appStoreCompatible' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6
    static let appStoreCompatible = (
               ^