### PR TITLE
Install swiftlint on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: SwiftLint
-      run: swiftlint
+      run: brew install swiftlint && swiftlint
 
   tests:
     runs-on: macos-latest


### PR DESCRIPTION
Swiftlint appears to be missing from the GH actions runners. Let's fix it.